### PR TITLE
CICD: Fix cloud init docker compose auto start

### DIFF
--- a/cicd/cloud-init.yml
+++ b/cicd/cloud-init.yml
@@ -121,6 +121,7 @@ write_files:
             - targets:
                 - 'obelix-basket:8082'
 
-# language=bash
-#runcmd:
-#  - docker compose up -d
+#language=bash
+runcmd:
+  - cd /home/obelix
+  - docker compose up -d


### PR DESCRIPTION
Currently the docker compose configuration is not started, when the VM is created. The VM (cloud init file) should automatically start the necessary services, to enable a faster startup so that we don't have to connect to it first and start it from the Github Actions.
Follow up of #60 