### PR TITLE
CICD: Update frontend CI permissions

### DIFF
--- a/.github/workflows/frontend-ci-build-publish.yaml
+++ b/.github/workflows/frontend-ci-build-publish.yaml
@@ -6,6 +6,10 @@ permissions:
 
 on:
   push:
+    branches:
+      - master
+    paths:
+      - 'frontend/**'
   pull_request:
     types: [ opened, synchronize, reopened ]
     paths:


### PR DESCRIPTION
relates to #18 
Dieses PR erweitert das Frontend CI-Workflow um explizite GitHub-Permissions und entfernt die Prüfung, ob die Tests erfolgreich waren, vor dem Pushen des Docker-Images. Dadurch wird der Workflow klarer bezüglich der benötigten Rechte und das Image wird immer gepusht, unabhängig vom Testergebnis.